### PR TITLE
chore: update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,15 +11,3 @@
 
 - [ ] Yes
 - [ ] No
-
-
-## Types of changes
-What types of changes does your code introduce to this repository?
-
-- [ ] Bugfix
-- [ ] Feature
-- [ ] Code style update (formatting, renaming)
-- [ ] Refactoring (no functional changes, no API changes)
-- [ ] Build related changes
-- [ ] Documentation content changes
-- [ ] Other (please describe):

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,18 @@
-## PR Checklist
-<!-- READ AND MARK EACH CHECKBOX WITH AN [X] -->
-Please check if your PR fulfills the following requirements:
-- [ ] Lint has passed locally and any fixes were made for failures
-- [ ] Docs have been reviewed and added/updated if needed (for bug fixes/features)
-- [ ] Changelog has been updated, if applicable
-- [ ] Build was run locally and any changes were pushed
-- [ ] Tests for the changes have been added (for bug fixes/features)
-
 ## Intent
 <!-- What are you trying to achieve with this PR?  -->
 
+
 ## Proposed changes
 <!-- Compared to the target branch, what have you changed? -->
+
+
+## Does this introduce a breaking change?
+<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
+
+- [ ] Yes
+- [ ] No
+
+
 ## Types of changes
 What types of changes does your code introduce to this repository?
 
@@ -22,14 +23,3 @@ What types of changes does your code introduce to this repository?
 - [ ] Build related changes
 - [ ] Documentation content changes
 - [ ] Other (please describe):
-
- ## Does this introduce a breaking change?
-
-- [ ] Yes
-- [ ] No
-
-<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
-
-<!-- 
-## Further comments
--->


### PR DESCRIPTION
## Intent

Change gorilainvest's default PR template to make it more readable and improve developer experience interacting with it.

*This Pull Request is an example application of the template it proposes.*

## Proposed changes

### Move `Intent` and `Proposed changes` to the top

This is the most core and critical information on the document. With this change, the reviewers can understand the scope of the changes much faster than with current template.

### Move `Does this introduce a breaking change` upper

This is also helps reviewers know how critical the PR is faster.

### Remove `PR Checklist`

Currently, a great portion of PR authors just ignore those fields. We can (and should) be sure about all of these requirements through repository automation. Removing this section makes it easier to read PR's body.

### Remove `Types of changes`

There are more effective ways to describe the type of change: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). It is easy to declare, easy to enforce through automation and as a bonus, we can filter Pull Requests by type using the search.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [X] Yes
- [ ] No
